### PR TITLE
Upgrade to nette 3

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -51,6 +51,7 @@
 		<exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingTraversablePropertyTypeHintSpecification"/>
 		<exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingTraversableReturnTypeHintSpecification"/>
 		<exclude name="SlevomatCodingStandard.Functions.TrailingCommaInCall.MissingTrailingComma"/><!-- PHP 7.3 -->
+		<exclude name="SlevomatCodingStandard.Numbers.RequireNumericLiteralSeparator.RequiredNumericLiteralSeparator"/><!-- PHP 7.4 -->
 	</rule>
 
 	<rule ref="SlevomatCodingStandard.TypeHints.DeclareStrictTypes">

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -8,3 +8,9 @@ parameters:
 		-
 			message: '#Call to an undefined method ReflectionType::getName\(\)\.#'
 			path: %rootDir%/../../../src/Nette/DI/Extension.php
+
+			# === This is because of Nette DI 2.4/3.0 compatibility ===
+		-
+			message: '#Call to function method_exists\(\) with .Nette\\\\DI…. and .getConfigSchema. will always evaluate to true\.#'
+			path: %rootDir%/../../../src/Nette/DI/Extension.php
+			count: 1

--- a/src/Nette/DI/Extension.php
+++ b/src/Nette/DI/Extension.php
@@ -78,7 +78,7 @@ class Extension extends Nette\DI\CompilerExtension
 
 
 	/**
-	 * @param array<string, mixed> $configs
+	 * @param array<string, mixed> $configs @todo \stdClass after Nette 2.4 will be dropped
 	 */
 	private function loadConfiguration30(array $configs): void
 	{
@@ -205,17 +205,14 @@ class Extension extends Nette\DI\CompilerExtension
 				'explain' => Schema\Expect::bool(FALSE),
 				'notices' => Schema\Expect::bool(FALSE),
 			])
-		)->before(static function ($val) {
-			foreach ($val as $key => $values) {
-				if ($key === 'errorVerbosity') {
-					if (!isset($val['autowired'])) {
-						$val['autowired'] = TRUE;
-					}
-					$val = ['default' => $val];
-					break;
+		)->before(static function ($config) {
+			foreach ($config as $values) {
+				if (\is_scalar($values)) {
+					$config = ['default' => $config];
 				}
+				break;
 			}
-			return $val;
+			return $config;
 		});
 	}
 

--- a/tests/BasicTest.php
+++ b/tests/BasicTest.php
@@ -19,6 +19,7 @@ class BasicTest extends Tester\TestCase
 		$loader = new DI\Config\Loader();
 		$config = $loader->load(Tester\FileMock::create('
 		database:
+			debugger: no
 			config:
 				host: localhost
 				port: 5432
@@ -26,7 +27,6 @@ class BasicTest extends Tester\TestCase
 				password: postgres
 				dbname: postgres
 				connect_timeout: 5
-			debugger: no
 			lazy: yes
 		', 'neon'));
 


### PR DESCRIPTION
- used Nette\Schema
- validate structure is copied from [nette\database](/nette/database/blob/master/src/Bridges/DatabaseDI/DatabaseExtension.php)
- the validation was missing for connect_timeout
- upgrade behavior with autowired
  - before you must set autowired like first in list of connections
  - now if second connection has autowired true that is accepted